### PR TITLE
Upgrade to AWS Load Balancer Controller

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,3 +8,4 @@
 
 - Daniel Randall &lt;dgrandall@me.com&gt;
 - Samer Shami &lt;gitkraken@shogun.work&gt;
+- Bret Mogilefsky &lt;bmogilefsky+albcontroller@gmail.com&gt;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2021-01-05
+
+### Updated
+
+- Renamed, now uses the AWS Load Balancer Controller (v2, formerly known as the
+  AWS ALB Ingress Controller)
+
+### Added
+
+- Variable `aws_load_balancer_controller_chart_version`
+
+### Removed
+
+- Variable `aws_alb_ingress_controller_version`
+
+
 ## [3.4.0] - 2020-06-04
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Variable `aws_load_balancer_controller_chart_version`
+- Variable `alb_controller_depends_on`
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Welcome!
+
+We're so glad you're thinking about contributing to a [open source project of the U.S. government](https://code.gov/)! If you're unsure about anything, just ask -- or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
+
+We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
+
+## Policies
+
+We want to ensure a welcoming environment for all of our projects. Our staff follow the [TTS Code of Conduct](https://18f.gsa.gov/code-of-conduct/) and all contributors should do the same.
+
+We adhere to the [18F Open Source Policy](https://github.com/18f/open-source-policy). If you have any questions, just [shoot us an email](mailto:18f@gsa.gov).
+
+As part of a U.S. government agency, the General Services Administration (GSA)’s Technology Transformation Services (TTS) takes seriously our responsibility to protect the public’s information, including financial and personal information, from unwarranted disclosure. For more information about security and vulnerability disclosure for our projects, please read our [18F Vulnerability Disclosure Policy](https://18f.gsa.gov/vulnerability-disclosure-policy/).
+
+## Public domain
+
+This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+All contributions to this project will be released under the CC0 dedication. By submitting a pull request or issue, you are agreeing to comply with this waiver of copyright interest.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# Terraform module: AWS ALB Ingress Controller installation
+# Terraform module: AWS Load Balancer Controller installation
 
-This Terraform module can be used to install the [AWS ALB Ingress Controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller)
+This Terraform module can be used to install the [AWS Load Balancer
+Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller)
 into a Kubernetes cluster.
 
 ## Improved integration with Amazon Elastic Kubernetes Service (EKS)
 
-This module can be used to install the ALB Ingress controller into a "vanilla" Kubernetes cluster (which is the default)
+This module can be used to install the AWS Load Balancer controller into a "vanilla" Kubernetes cluster (which is the default)
 or it can be used to integrate tightly with AWS-managed [EKS](https://aws.amazon.com/eks/) clusters which allows the deployed pods to
 [use IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This module can be used to install the ALB Ingress controller into a "vanilla" K
 or it can be used to integrate tightly with AWS-managed [EKS](https://aws.amazon.com/eks/) clusters which allows the deployed pods to
 [use IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
 
-It is required, that an OpenID connect provider [has already been created](https://www.terraform.io/docs/providers/aws/r/eks_cluster.html#example-iam-role-for-eks-cluster) for your EKS cluster for this feature to work.
+It is required that an OpenID connect provider [has already been created](https://www.terraform.io/docs/providers/aws/r/eks_cluster.html#example-iam-role-for-eks-cluster) for your EKS cluster for this feature to work.
 
 Just make sure that you set the variable `k8s_cluster_type` to `eks` type if running on EKS.
 
@@ -17,8 +17,8 @@ Just make sure that you set the variable `k8s_cluster_type` to `eks` type if run
 
 ### EKS deployment
 
-To deploy the AWS ALB Ingress Controller into an EKS cluster, the following
-snippet might be used.
+To deploy the AWS Load Balancer Controller into an EKS cluster, use the following
+snippet as an example.
 
 ```hcl
 locals {

--- a/main.tf
+++ b/main.tf
@@ -69,149 +69,206 @@ resource "aws_iam_role" "this" {
   assume_role_policy = var.k8s_cluster_type == "vanilla" ? data.aws_iam_policy_document.ec2_assume_role[0].json : data.aws_iam_policy_document.eks_oidc_assume_role[0].json
 }
 
-data "aws_iam_policy_document" "alb_management" {
-  statement {
-    actions = [
-      "acm:DescribeCertificate",
-      "acm:ListCertificates",
-      "acm:GetCertificate",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
-      "ec2:AuthorizeSecurityGroupIngress",
-      "ec2:CreateSecurityGroup",
-      "ec2:CreateTags",
-      "ec2:DeleteTags",
-      "ec2:DeleteSecurityGroup",
-      "ec2:DescribeAccountAttributes",
-      "ec2:DescribeAddresses",
-      "ec2:DescribeInstances",
-      "ec2:DescribeInstanceStatus",
-      "ec2:DescribeInternetGateways",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DescribeSecurityGroups",
-      "ec2:DescribeSubnets",
-      "ec2:DescribeTags",
-      "ec2:DescribeVpcs",
-      "ec2:ModifyInstanceAttribute",
-      "ec2:ModifyNetworkInterfaceAttribute",
-      "ec2:RevokeSecurityGroupIngress",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
-      "elasticloadbalancing:AddListenerCertificates",
-      "elasticloadbalancing:AddTags",
-      "elasticloadbalancing:CreateListener",
-      "elasticloadbalancing:CreateLoadBalancer",
-      "elasticloadbalancing:CreateRule",
-      "elasticloadbalancing:CreateTargetGroup",
-      "elasticloadbalancing:DeleteListener",
-      "elasticloadbalancing:DeleteLoadBalancer",
-      "elasticloadbalancing:DeleteRule",
-      "elasticloadbalancing:DeleteTargetGroup",
-      "elasticloadbalancing:DeregisterTargets",
-      "elasticloadbalancing:DescribeListenerCertificates",
-      "elasticloadbalancing:DescribeListeners",
-      "elasticloadbalancing:DescribeLoadBalancers",
-      "elasticloadbalancing:DescribeLoadBalancerAttributes",
-      "elasticloadbalancing:DescribeRules",
-      "elasticloadbalancing:DescribeSSLPolicies",
-      "elasticloadbalancing:DescribeTags",
-      "elasticloadbalancing:DescribeTargetGroups",
-      "elasticloadbalancing:DescribeTargetGroupAttributes",
-      "elasticloadbalancing:DescribeTargetHealth",
-      "elasticloadbalancing:ModifyListener",
-      "elasticloadbalancing:ModifyLoadBalancerAttributes",
-      "elasticloadbalancing:ModifyRule",
-      "elasticloadbalancing:ModifyTargetGroup",
-      "elasticloadbalancing:ModifyTargetGroupAttributes",
-      "elasticloadbalancing:RegisterTargets",
-      "elasticloadbalancing:RemoveListenerCertificates",
-      "elasticloadbalancing:RemoveTags",
-      "elasticloadbalancing:SetIpAddressType",
-      "elasticloadbalancing:SetSecurityGroups",
-      "elasticloadbalancing:SetSubnets",
-      "elasticloadbalancing:SetWebACL",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
-      "iam:CreateServiceLinkedRole",
-      "iam:GetServerCertificate",
-      "iam:ListServerCertificates",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
-      "cognito-idp:DescribeUserPoolClient",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
-      "tag:GetResources",
-      "tag:TagResources",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
-      "waf:GetWebACL",
-      "waf-regional:GetWebACLForResource",
-      "waf-regional:GetWebACL",
-      "waf-regional:AssociateWebACL",
-      "waf-regional:DisassociateWebACL",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
-      "wafv2:GetWebACL",
-      "wafv2:GetWebACLForResource",
-      "wafv2:AssociateWebACL",
-      "wafv2:DisassociateWebACL"
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
-      "shield:DescribeProtection",
-      "shield:GetSubscriptionState",
-      "shield:DeleteProtection",
-      "shield:CreateProtection",
-      "shield:DescribeSubscription",
-      "shield:ListProtections"
-    ]
-    resources = ["*"]
-  }
-}
-
 resource "aws_iam_policy" "this" {
   name        = "${var.aws_resource_name_prefix}${var.k8s_cluster_name}-alb-management"
   description = "Permissions that are required to manage AWS Application Load Balancers."
   path        = local.aws_iam_path_prefix
-  policy      = data.aws_iam_policy_document.alb_management.json
+  # We use a heredoc for the policy JSON so that we can more easily diff and
+  # copy/paste from upstream.
+  # Source: `curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.1.0/docs/install/iam_policy.json`
+  policy      = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole",
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "this" {

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "eks_oidc_assume_role" {
 }
 
 resource "aws_iam_role" "this" {
-  name        = "${var.aws_resource_name_prefix}${var.k8s_cluster_name}-aws-load-balancer-controller"
+  name        = substr("${var.aws_resource_name_prefix}${var.k8s_cluster_name}-aws-load-balancer-controller", 0, 64)
   description = "Permissions required by the Kubernetes AWS Load Balancer controller to do its job."
   path        = local.aws_iam_path_prefix
 

--- a/main.tf
+++ b/main.tf
@@ -82,199 +82,199 @@ resource "aws_iam_policy" "this" {
   # We use a heredoc for the policy JSON so that we can more easily diff and
   # copy/paste from upstream.
   # Source: `curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.1.0/docs/install/iam_policy.json`
-  policy = <<POLICY
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreateServiceLinkedRole",
-                "ec2:DescribeAccountAttributes",
-                "ec2:DescribeAddresses",
-                "ec2:DescribeInternetGateways",
-                "ec2:DescribeVpcs",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeInstances",
-                "ec2:DescribeNetworkInterfaces",
-                "ec2:DescribeTags",
-                "elasticloadbalancing:DescribeLoadBalancers",
-                "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                "elasticloadbalancing:DescribeListeners",
-                "elasticloadbalancing:DescribeListenerCertificates",
-                "elasticloadbalancing:DescribeSSLPolicies",
-                "elasticloadbalancing:DescribeRules",
-                "elasticloadbalancing:DescribeTargetGroups",
-                "elasticloadbalancing:DescribeTargetGroupAttributes",
-                "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:DescribeTags"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "cognito-idp:DescribeUserPoolClient",
-                "acm:ListCertificates",
-                "acm:DescribeCertificate",
-                "iam:ListServerCertificates",
-                "iam:GetServerCertificate",
-                "waf-regional:GetWebACL",
-                "waf-regional:GetWebACLForResource",
-                "waf-regional:AssociateWebACL",
-                "waf-regional:DisassociateWebACL",
-                "wafv2:GetWebACL",
-                "wafv2:GetWebACLForResource",
-                "wafv2:AssociateWebACL",
-                "wafv2:DisassociateWebACL",
-                "shield:GetSubscriptionState",
-                "shield:DescribeProtection",
-                "shield:CreateProtection",
-                "shield:DeleteProtection"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:RevokeSecurityGroupIngress"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:CreateSecurityGroup"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:CreateTags"
-            ],
-            "Resource": "arn:aws:ec2:*:*:security-group/*",
-            "Condition": {
-                "StringEquals": {
-                    "ec2:CreateAction": "CreateSecurityGroup"
-                },
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:CreateTags",
-                "ec2:DeleteTags"
-            ],
-            "Resource": "arn:aws:ec2:*:*:security-group/*",
-            "Condition": {
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:RevokeSecurityGroupIngress",
-                "ec2:DeleteSecurityGroup"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "Null": {
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:CreateLoadBalancer",
-                "elasticloadbalancing:CreateTargetGroup"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:CreateListener",
-                "elasticloadbalancing:DeleteListener",
-                "elasticloadbalancing:CreateRule",
-                "elasticloadbalancing:DeleteRule"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:RemoveTags"
-            ],
-            "Resource": [
-                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-            ],
-            "Condition": {
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                "elasticloadbalancing:SetIpAddressType",
-                "elasticloadbalancing:SetSecurityGroups",
-                "elasticloadbalancing:SetSubnets",
-                "elasticloadbalancing:DeleteLoadBalancer",
-                "elasticloadbalancing:ModifyTargetGroup",
-                "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:DeleteTargetGroup"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "Null": {
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:DeregisterTargets"
-            ],
-            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:SetWebAcl",
-                "elasticloadbalancing:ModifyListener",
-                "elasticloadbalancing:AddListenerCertificates",
-                "elasticloadbalancing:RemoveListenerCertificates",
-                "elasticloadbalancing:ModifyRule"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-POLICY
+  policy = <<-POLICY
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "iam:CreateServiceLinkedRole",
+                  "ec2:DescribeAccountAttributes",
+                  "ec2:DescribeAddresses",
+                  "ec2:DescribeInternetGateways",
+                  "ec2:DescribeVpcs",
+                  "ec2:DescribeSubnets",
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeNetworkInterfaces",
+                  "ec2:DescribeTags",
+                  "elasticloadbalancing:DescribeLoadBalancers",
+                  "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                  "elasticloadbalancing:DescribeListeners",
+                  "elasticloadbalancing:DescribeListenerCertificates",
+                  "elasticloadbalancing:DescribeSSLPolicies",
+                  "elasticloadbalancing:DescribeRules",
+                  "elasticloadbalancing:DescribeTargetGroups",
+                  "elasticloadbalancing:DescribeTargetGroupAttributes",
+                  "elasticloadbalancing:DescribeTargetHealth",
+                  "elasticloadbalancing:DescribeTags"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "cognito-idp:DescribeUserPoolClient",
+                  "acm:ListCertificates",
+                  "acm:DescribeCertificate",
+                  "iam:ListServerCertificates",
+                  "iam:GetServerCertificate",
+                  "waf-regional:GetWebACL",
+                  "waf-regional:GetWebACLForResource",
+                  "waf-regional:AssociateWebACL",
+                  "waf-regional:DisassociateWebACL",
+                  "wafv2:GetWebACL",
+                  "wafv2:GetWebACLForResource",
+                  "wafv2:AssociateWebACL",
+                  "wafv2:DisassociateWebACL",
+                  "shield:GetSubscriptionState",
+                  "shield:DescribeProtection",
+                  "shield:CreateProtection",
+                  "shield:DeleteProtection"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:AuthorizeSecurityGroupIngress",
+                  "ec2:RevokeSecurityGroupIngress"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:CreateSecurityGroup"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:CreateTags"
+              ],
+              "Resource": "arn:aws:ec2:*:*:security-group/*",
+              "Condition": {
+                  "StringEquals": {
+                      "ec2:CreateAction": "CreateSecurityGroup"
+                  },
+                  "Null": {
+                      "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:CreateTags",
+                  "ec2:DeleteTags"
+              ],
+              "Resource": "arn:aws:ec2:*:*:security-group/*",
+              "Condition": {
+                  "Null": {
+                      "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:AuthorizeSecurityGroupIngress",
+                  "ec2:RevokeSecurityGroupIngress",
+                  "ec2:DeleteSecurityGroup"
+              ],
+              "Resource": "*",
+              "Condition": {
+                  "Null": {
+                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:CreateLoadBalancer",
+                  "elasticloadbalancing:CreateTargetGroup"
+              ],
+              "Resource": "*",
+              "Condition": {
+                  "Null": {
+                      "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:CreateListener",
+                  "elasticloadbalancing:DeleteListener",
+                  "elasticloadbalancing:CreateRule",
+                  "elasticloadbalancing:DeleteRule"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:AddTags",
+                  "elasticloadbalancing:RemoveTags"
+              ],
+              "Resource": [
+                  "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                  "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                  "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+              ],
+              "Condition": {
+                  "Null": {
+                      "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                  "elasticloadbalancing:SetIpAddressType",
+                  "elasticloadbalancing:SetSecurityGroups",
+                  "elasticloadbalancing:SetSubnets",
+                  "elasticloadbalancing:DeleteLoadBalancer",
+                  "elasticloadbalancing:ModifyTargetGroup",
+                  "elasticloadbalancing:ModifyTargetGroupAttributes",
+                  "elasticloadbalancing:DeleteTargetGroup"
+              ],
+              "Resource": "*",
+              "Condition": {
+                  "Null": {
+                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:RegisterTargets",
+                  "elasticloadbalancing:DeregisterTargets"
+              ],
+              "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:SetWebAcl",
+                  "elasticloadbalancing:ModifyListener",
+                  "elasticloadbalancing:AddListenerCertificates",
+                  "elasticloadbalancing:RemoveListenerCertificates",
+                  "elasticloadbalancing:ModifyRule"
+              ],
+              "Resource": "*"
+          }
+      ]
+  }
+  POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "this" {
@@ -451,19 +451,19 @@ resource "null_resource" "supply_target_group_arns" {
     environment = {
       KUBECONFIG = base64encode(data.template_file.kubeconfig.rendered)
     }
-    command = <<EOF
-cat <<YAML | kubectl -n ${var.k8s_namespace} --kubeconfig <(echo $KUBECONFIG | base64 --decode) apply -f -
-apiVersion: elbv2.k8s.aws/v1beta1
-kind: TargetGroupBinding
-metadata:
-  name:
-spec:
-  serviceRef:
-    name: awesome-service # route traffic to the awesome-service
-    port: 80
-  targetGroupARN: ${var.alb_target_group_arns}
-YAML
-EOF
+    command = <<-EOF
+      cat <<YAML | kubectl -n ${var.k8s_namespace} --kubeconfig <(echo $KUBECONFIG | base64 --decode) apply -f -
+      apiVersion: elbv2.k8s.aws/v1beta1
+      kind: TargetGroupBinding
+      metadata:
+        name:
+      spec:
+        serviceRef:
+          name: awesome-service # route traffic to the awesome-service
+          port: 80
+        targetGroupARN: ${var.alb_target_group_arns}
+      YAML
+    EOF
   }
   depends_on = [helm_release.alb_controller]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,11 @@
 locals {
-  alb_controller_helm_repo    = "https://aws.github.io/eks-charts"
-  alb_controller_chart_name   = "aws-load-balancer-controller"
-  alb_controller_chart_version      = var.aws_load_balancer_controller_chart_version
-  aws_alb_ingress_class                   = "alb"
-  aws_vpc_id                              = data.aws_vpc.selected.id
-  aws_region_name                         = data.aws_region.current.name
-  aws_iam_path_prefix                     = var.aws_iam_path_prefix == "" ? null : var.aws_iam_path_prefix
+  alb_controller_helm_repo     = "https://aws.github.io/eks-charts"
+  alb_controller_chart_name    = "aws-load-balancer-controller"
+  alb_controller_chart_version = var.aws_load_balancer_controller_chart_version
+  aws_alb_ingress_class        = "alb"
+  aws_vpc_id                   = data.aws_vpc.selected.id
+  aws_region_name              = data.aws_region.current.name
+  aws_iam_path_prefix          = var.aws_iam_path_prefix == "" ? null : var.aws_iam_path_prefix
 }
 
 data "aws_vpc" "selected" {
@@ -82,7 +82,7 @@ resource "aws_iam_policy" "this" {
   # We use a heredoc for the policy JSON so that we can more easily diff and
   # copy/paste from upstream.
   # Source: `curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.1.0/docs/install/iam_policy.json`
-  policy      = <<POLICY
+  policy = <<POLICY
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -440,7 +440,7 @@ data "template_file" "kubeconfig" {
 # Since the kubernetes_provider cannot yet handle CRDs, we need to set any
 # supplied TargetGroupBinding using a null_resource.
 #
-# The method use below for securely specifying the kubeconfig to provisioners
+# The method used below for securely specifying the kubeconfig to provisioners
 # without spilling secrets into the logs comes from:
 # https://medium.com/citihub/a-more-secure-way-to-call-kubectl-from-terraform-1052adf37af8
 
@@ -451,7 +451,7 @@ resource "null_resource" "supply_target_group_arns" {
     environment = {
       KUBECONFIG = base64encode(data.template_file.kubeconfig.rendered)
     }
-    command     = <<EOF
+    command = <<EOF
 cat <<YAML | kubectl -n ${var.k8s_namespace} --kubeconfig <(echo $KUBECONFIG | base64 --decode) apply -f -
 apiVersion: elbv2.k8s.aws/v1beta1
 kind: TargetGroupBinding

--- a/main.tf
+++ b/main.tf
@@ -298,6 +298,7 @@ resource "kubernetes_service_account" "this" {
       "app.kubernetes.io/managed-by" = "terraform"
     }
   }
+  depends_on = [var.alb_controller_depends_on]
 }
 
 resource "kubernetes_cluster_role" "this" {
@@ -355,6 +356,7 @@ resource "kubernetes_cluster_role" "this" {
       "watch",
     ]
   }
+  depends_on = [var.alb_controller_depends_on]
 }
 
 resource "kubernetes_cluster_role_binding" "this" {

--- a/main.tf
+++ b/main.tf
@@ -392,25 +392,18 @@ resource "helm_release" "alb_controller" {
   namespace  = var.k8s_namespace
   atomic     = true
   timeout    = 900
-  set {
-    name  = "clusterName"
-    value = var.k8s_cluster_name
-  }
-  set {
-    name  = "serviceAccount.create"
-    value = (var.k8s_cluster_type != "eks")
-  }
-  set {
-    name  = "serviceAccount.name"
-    value = (var.k8s_cluster_type == "eks") ? kubernetes_service_account.this.metadata[0].name : null
-  }
-  set {
-    name  = "region"
-    value = local.aws_region_name
-  }
-  set {
-    name  = "vpcId"
-    value = local.aws_vpc_id
+  dynamic "set" {
+    for_each = {
+      "clusterName"           = var.k8s_cluster_name
+      "serviceAccount.create" = (var.k8s_cluster_type != "eks")
+      "serviceAccount.name"   = (var.k8s_cluster_type == "eks") ? kubernetes_service_account.this.metadata[0].name : null
+      "region"                = local.aws_region_name
+      "vpcId"                 = local.aws_vpc_id
+    }
+    content {
+      name  = set.key
+      value = set.value
+    }
   }
 
   depends_on = [var.alb_controller_depends_on]

--- a/main.tf
+++ b/main.tf
@@ -440,7 +440,7 @@ data "template_file" "kubeconfig" {
 # https://medium.com/citihub/a-more-secure-way-to-call-kubectl-from-terraform-1052adf37af8
 
 resource "null_resource" "supply_target_group_arns" {
-  count = (var.alb_target_group_arns != "") ? 1 : 0
+  count = (length(var.target_groups) > 0) ? length(var.target_groups) : 0
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     environment = {
@@ -451,12 +451,12 @@ resource "null_resource" "supply_target_group_arns" {
       apiVersion: elbv2.k8s.aws/v1beta1
       kind: TargetGroupBinding
       metadata:
-        name:
+        name: ${lookup(var.target_groups[count.index], "name", "")}-tgb
       spec:
         serviceRef:
-          name: awesome-service # route traffic to the awesome-service
-          port: 80
-        targetGroupARN: ${var.alb_target_group_arns}
+          name: ${lookup(var.target_groups[count.index], "name", "")}
+          port: ${lookup(var.target_groups[count.index], "backend_port", "")}
+        targetGroupARN: ${lookup(var.target_groups[count.index], "target_group_arn", "")}
       YAML
     EOF
   }

--- a/main.tf
+++ b/main.tf
@@ -288,6 +288,7 @@ resource "kubernetes_service_account" "this" {
     }
     labels = {
       "app.kubernetes.io/name"       = "aws-load-balancer-controller"
+      "app.kubernetes.io/component"  = "controller"
       "app.kubernetes.io/managed-by" = "terraform"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -416,7 +416,6 @@ resource "helm_release" "alb_controller" {
   namespace  = var.k8s_namespace
   atomic     = true
   timeout    = 900
-
   dynamic "set" {
     for_each = {
       "clusterName"           = var.k8s_cluster_name

--- a/main.tf
+++ b/main.tf
@@ -81,199 +81,215 @@ resource "aws_iam_policy" "this" {
   path        = local.aws_iam_path_prefix
   # We use a heredoc for the policy JSON so that we can more easily diff and
   # copy/paste from upstream.
-  # Source: `curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.1.0/docs/install/iam_policy.json`
+  # Source: `curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json`
   policy = <<-POLICY
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "iam:CreateServiceLinkedRole",
-                  "ec2:DescribeAccountAttributes",
-                  "ec2:DescribeAddresses",
-                  "ec2:DescribeInternetGateways",
-                  "ec2:DescribeVpcs",
-                  "ec2:DescribeSubnets",
-                  "ec2:DescribeSecurityGroups",
-                  "ec2:DescribeInstances",
-                  "ec2:DescribeNetworkInterfaces",
-                  "ec2:DescribeTags",
-                  "elasticloadbalancing:DescribeLoadBalancers",
-                  "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                  "elasticloadbalancing:DescribeListeners",
-                  "elasticloadbalancing:DescribeListenerCertificates",
-                  "elasticloadbalancing:DescribeSSLPolicies",
-                  "elasticloadbalancing:DescribeRules",
-                  "elasticloadbalancing:DescribeTargetGroups",
-                  "elasticloadbalancing:DescribeTargetGroupAttributes",
-                  "elasticloadbalancing:DescribeTargetHealth",
-                  "elasticloadbalancing:DescribeTags"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "cognito-idp:DescribeUserPoolClient",
-                  "acm:ListCertificates",
-                  "acm:DescribeCertificate",
-                  "iam:ListServerCertificates",
-                  "iam:GetServerCertificate",
-                  "waf-regional:GetWebACL",
-                  "waf-regional:GetWebACLForResource",
-                  "waf-regional:AssociateWebACL",
-                  "waf-regional:DisassociateWebACL",
-                  "wafv2:GetWebACL",
-                  "wafv2:GetWebACLForResource",
-                  "wafv2:AssociateWebACL",
-                  "wafv2:DisassociateWebACL",
-                  "shield:GetSubscriptionState",
-                  "shield:DescribeProtection",
-                  "shield:CreateProtection",
-                  "shield:DeleteProtection"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "ec2:AuthorizeSecurityGroupIngress",
-                  "ec2:RevokeSecurityGroupIngress"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "ec2:CreateSecurityGroup"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "ec2:CreateTags"
-              ],
-              "Resource": "arn:aws:ec2:*:*:security-group/*",
-              "Condition": {
-                  "StringEquals": {
-                      "ec2:CreateAction": "CreateSecurityGroup"
-                  },
-                  "Null": {
-                      "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
-                  }
-              }
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "ec2:CreateTags",
-                  "ec2:DeleteTags"
-              ],
-              "Resource": "arn:aws:ec2:*:*:security-group/*",
-              "Condition": {
-                  "Null": {
-                      "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                  }
-              }
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "ec2:AuthorizeSecurityGroupIngress",
-                  "ec2:RevokeSecurityGroupIngress",
-                  "ec2:DeleteSecurityGroup"
-              ],
-              "Resource": "*",
-              "Condition": {
-                  "Null": {
-                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                  }
-              }
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "elasticloadbalancing:CreateLoadBalancer",
-                  "elasticloadbalancing:CreateTargetGroup"
-              ],
-              "Resource": "*",
-              "Condition": {
-                  "Null": {
-                      "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
-                  }
-              }
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "elasticloadbalancing:CreateListener",
-                  "elasticloadbalancing:DeleteListener",
-                  "elasticloadbalancing:CreateRule",
-                  "elasticloadbalancing:DeleteRule"
-              ],
-              "Resource": "*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "elasticloadbalancing:AddTags",
-                  "elasticloadbalancing:RemoveTags"
-              ],
-              "Resource": [
-                  "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-                  "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-                  "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-              ],
-              "Condition": {
-                  "Null": {
-                      "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                  }
-              }
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                  "elasticloadbalancing:SetIpAddressType",
-                  "elasticloadbalancing:SetSecurityGroups",
-                  "elasticloadbalancing:SetSubnets",
-                  "elasticloadbalancing:DeleteLoadBalancer",
-                  "elasticloadbalancing:ModifyTargetGroup",
-                  "elasticloadbalancing:ModifyTargetGroupAttributes",
-                  "elasticloadbalancing:DeleteTargetGroup"
-              ],
-              "Resource": "*",
-              "Condition": {
-                  "Null": {
-                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                  }
-              }
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "elasticloadbalancing:RegisterTargets",
-                  "elasticloadbalancing:DeregisterTargets"
-              ],
-              "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
-          },
-          {
-              "Effect": "Allow",
-              "Action": [
-                  "elasticloadbalancing:SetWebAcl",
-                  "elasticloadbalancing:ModifyListener",
-                  "elasticloadbalancing:AddListenerCertificates",
-                  "elasticloadbalancing:RemoveListenerCertificates",
-                  "elasticloadbalancing:ModifyRule"
-              ],
-              "Resource": "*"
-          }
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateServiceLinkedRole",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeInstances",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeTags",
+        "ec2:GetCoipPoolUsage",
+        "ec2:DescribeCoipPools",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeListenerCertificates",
+        "elasticloadbalancing:DescribeSSLPolicies",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetGroupAttributes",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:DescribeTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPoolClient",
+        "acm:ListCertificates",
+        "acm:DescribeCertificate",
+        "iam:ListServerCertificates",
+        "iam:GetServerCertificate",
+        "waf-regional:GetWebACL",
+        "waf-regional:GetWebACLForResource",
+        "waf-regional:AssociateWebACL",
+        "waf-regional:DisassociateWebACL",
+        "wafv2:GetWebACL",
+        "wafv2:GetWebACLForResource",
+        "wafv2:AssociateWebACL",
+        "wafv2:DisassociateWebACL",
+        "shield:GetSubscriptionState",
+        "shield:DescribeProtection",
+        "shield:CreateProtection",
+        "shield:DeleteProtection"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSecurityGroup"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "CreateSecurityGroup"
+        },
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:DeleteSecurityGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateTargetGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:DeleteRule"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
       ]
-  }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:DeleteTargetGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:DeregisterTargets"
+      ],
+      "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:SetWebAcl",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:ModifyRule"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
   POLICY
 }
 
@@ -399,6 +415,7 @@ resource "helm_release" "alb_controller" {
       "serviceAccount.name"   = (var.k8s_cluster_type == "eks") ? kubernetes_service_account.this.metadata[0].name : null
       "region"                = local.aws_region_name
       "vpcId"                 = local.aws_vpc_id
+      "hostNetwork"           = var.enable_host_networking
     }
     content {
       name  = set.key
@@ -457,6 +474,7 @@ resource "null_resource" "supply_target_group_arns" {
           name: ${lookup(var.target_groups[count.index], "name", "")}
           port: ${lookup(var.target_groups[count.index], "backend_port", "")}
         targetGroupARN: ${lookup(var.target_groups[count.index], "target_group_arn", "")}
+        targetType:  ${lookup(var.target_groups[count.index], "target_type", "instance")}
       YAML
     EOF
   }

--- a/main.tf
+++ b/main.tf
@@ -382,7 +382,7 @@ resource "helm_release" "using_iamserviceaccount" {
   repository = local.alb_controller_helm_repo
   chart      = local.alb_controller_chart_name
   version    = local.alb_controller_chart_version
-  namespace  = "kube-system"
+  namespace  = var.k8s_namespace
   atomic     = true
 
   set {
@@ -416,7 +416,7 @@ resource "helm_release" "not_using_iamserviceaccount" {
   repository = local.alb_controller_helm_repo
   chart      = local.alb_controller_chart_name
   version    = local.alb_controller_chart_version
-  namespace  = "kube-system"
+  namespace  = var.k8s_namespace
   atomic     = true
 
   set {

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,12 @@ data "aws_eks_cluster" "selected" {
   name  = var.k8s_cluster_name
 }
 
+# Authentication data for that cluster
+data "aws_eks_cluster_auth" "selected" {
+  count = var.k8s_cluster_type == "eks" ? 1 : 0
+  name  = var.k8s_cluster_name
+}
+
 data "aws_iam_policy_document" "ec2_assume_role" {
   count = var.k8s_cluster_type == "vanilla" ? 1 : 0
   statement {
@@ -434,3 +440,80 @@ resource "helm_release" "not_using_iamserviceaccount" {
   depends_on = [var.alb_controller_depends_on]
 }
 
+# Generate a kubeconfig file for the EKS cluster to use in provisioners
+data "template_file" "kubeconfig" {
+  template = <<-EOF
+    apiVersion: v1
+    kind: Config
+    current-context: terraform
+    clusters:
+    - name: ${data.aws_eks_cluster.selected[0].name}
+      cluster:
+        certificate-authority-data: ${data.aws_eks_cluster.selected[0].certificate_authority.0.data}
+        server: ${data.aws_eks_cluster.selected[0].endpoint}
+    contexts:
+    - name: terraform
+      context:
+        cluster: ${data.aws_eks_cluster.selected[0].name}
+        user: terraform
+    users:
+    - name: terraform
+      user:
+        token: ${data.aws_eks_cluster_auth.selected[0].token}
+  EOF
+}
+
+# Since the kubernetes_provider cannot yet handle CRDs, we need to set any
+# supplied TargetGroupBinding using a null_resource.
+#
+# The method use below for securely specifying the kubeconfig to provisioners
+# without spilling secrets into the logs comes from:
+# https://medium.com/citihub/a-more-secure-way-to-call-kubectl-from-terraform-1052adf37af8
+
+resource "null_resource" "supply_target_group_arns_no_iam" {
+  count = (var.alb_target_group_arns != "" && var.k8s_cluster_type == "vanilla") ? 1 : 0
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      KUBECONFIG = base64encode(data.template_file.kubeconfig.rendered)
+    }
+    command     = <<EOF
+cat <<YAML | kubectl -n ${var.k8s_namespace} --kubeconfig <(echo $KUBECONFIG | base64 --decode) apply -f -
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name:
+spec:
+  serviceRef:
+    name: awesome-service # route traffic to the awesome-service
+    port: 80
+  targetGroupARN: ${var.alb_target_group_arns}
+YAML
+EOF
+  }
+  depends_on = [ helm_release.not_using_iamserviceaccount ]
+}
+
+resource "null_resource" "supply_target_group_arns_iam" {
+  count = (var.alb_target_group_arns != "" && var.k8s_cluster_type == "eks") ? 1 : 0
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      KUBECONFIG = base64encode(data.template_file.kubeconfig.rendered)
+    }
+    command     = <<EOF
+cat <<YAML | kubectl -n ${var.k8s_namespace} --kubeconfig <(echo $KUBECONFIG | base64 --decode) apply -f -
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name:
+spec:
+  serviceRef:
+    name: awesome-service # route traffic to the awesome-service
+    port: 80
+  targetGroupARN: ${var.alb_target_group_arns}
+YAML
+EOF
+  }
+  depends_on = [ helm_release.using_iamserviceaccount ]
+}

--- a/main.tf
+++ b/main.tf
@@ -22,12 +22,14 @@ data "aws_caller_identity" "current" {}
 data "aws_eks_cluster" "selected" {
   count = var.k8s_cluster_type == "eks" ? 1 : 0
   name  = var.k8s_cluster_name
+  depends_on = [var.alb_controller_depends_on]
 }
 
 # Authentication data for that cluster
 data "aws_eks_cluster_auth" "selected" {
   count = var.k8s_cluster_type == "eks" ? 1 : 0
   name  = var.k8s_cluster_name
+  depends_on = [var.alb_controller_depends_on]
 }
 
 data "aws_iam_policy_document" "ec2_assume_role" {

--- a/main.tf
+++ b/main.tf
@@ -382,6 +382,8 @@ resource "helm_release" "using_iamserviceaccount" {
   chart      = local.alb_controller_chart_name
   version    = local.alb_controller_chart_version
   namespace  = "kube-system"
+  atomic     = true
+
   set {
     name  = "clusterName"
     value = var.k8s_cluster_name
@@ -412,6 +414,8 @@ resource "helm_release" "not_using_iamserviceaccount" {
   chart      = local.alb_controller_chart_name
   version    = local.alb_controller_chart_version
   namespace  = "kube-system"
+  atomic     = true
+
   set {
     name  = "clusterName"
     value = var.k8s_cluster_name

--- a/main.tf
+++ b/main.tf
@@ -390,7 +390,7 @@ resource "helm_release" "using_iamserviceaccount" {
   version    = local.alb_controller_chart_version
   namespace  = var.k8s_namespace
   atomic     = true
-
+  timeout    = 900
   set {
     name  = "clusterName"
     value = var.k8s_cluster_name
@@ -424,6 +424,7 @@ resource "helm_release" "not_using_iamserviceaccount" {
   version    = local.alb_controller_chart_version
   namespace  = var.k8s_namespace
   atomic     = true
+  timeout    = 900
 
   set {
     name  = "clusterName"

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,6 @@ resource "aws_iam_policy" "this" {
   path        = local.aws_iam_path_prefix
   # We use a heredoc for the policy JSON so that we can more easily diff and
   # copy/paste from upstream.
-
   # Source: `curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json`
   policy = <<-POLICY
 {

--- a/main.tf
+++ b/main.tf
@@ -405,6 +405,8 @@ resource "helm_release" "using_iamserviceaccount" {
     name  = "vpcId"
     value = local.aws_vpc_id
   }
+
+  depends_on = [var.alb_controller_depends_on]
 }
 
 resource "helm_release" "not_using_iamserviceaccount" {
@@ -429,5 +431,6 @@ resource "helm_release" "not_using_iamserviceaccount" {
     name  = "vpcId"
     value = local.aws_vpc_id
   }
+  depends_on = [var.alb_controller_depends_on]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -74,8 +74,8 @@ variable "alb_controller_depends_on" {
   description = "Resources that the module should wait for before starting the controller. For example if there is no node_group, 'aws_eks_fargate_profile.default'"
 }
 
-variable "alb_target_group_arns" {
+variable "target_groups" {
   description = "ARNs for existing load balancers that should be added via TargetGroupBindings. See https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/targetgroupbinding/targetgroupbinding/ for details"
-  type        = string
-  default     = ""
+  type        = any
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "k8s_cluster_name" {
 }
 
 variable "k8s_namespace" {
-  description = "Kubernetes namespace to deploy the AWS ALB Ingress Controller into."
+  description = "Kubernetes namespace to deploy the AWS Load Balancer Controller into."
   type        = string
   default     = "default"
 }
@@ -64,8 +64,8 @@ variable "aws_tags" {
   default     = {}
 }
 
-variable "aws_alb_ingress_controller_version" {
-  description = "The AWS ALB Ingress Controller version to use. See https://github.com/kubernetes-sigs/aws-alb-ingress-controller/releases for available versions"
+variable "aws_load_balancer_controller_chart_version" {
+  description = "The AWS Load Balancer Controller version to use. See https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases for available versions"
   type        = string
-  default     = "1.1.7"
+  default     = "1.1.1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,9 @@ variable "aws_load_balancer_controller_chart_version" {
 variable "alb_controller_depends_on" {
   description = "Resources that the module should wait for before starting the controller. For example if there is no node_group, 'aws_eks_fargate_profile.default'"
 }
+
+variable "alb_target_group_arns" {
+  description = "ARNs for existing load balancers that should be added via TargetGroupBindings. See https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/targetgroupbinding/targetgroupbinding/ for details"
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,7 @@ variable "aws_load_balancer_controller_chart_version" {
   type        = string
   default     = "1.1.1"
 }
+
+variable "alb_controller_depends_on" {
+  description = "Resources that the module should wait for before starting the controller. For example if there is no node_group, 'aws_eks_fargate_profile.default'"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "k8s_cluster_type" {
-  description = "Can be set to `vanilla` or `eks`. If set to `eks`, the Kubernetes cluster will be assumed to be run on EKS which will make sure that the AWS IAM Service integration works as supposed to."
+  description = "Can be set to `vanilla` or `eks`. If set to `eks`, the Kubernetes cluster will be assumed to be run on EKS which will make sure that the AWS IAM Service integration works as expected."
   type        = string
   default     = "vanilla"
 }
@@ -16,7 +16,7 @@ variable "k8s_namespace" {
 }
 
 variable "k8s_replicas" {
-  description = "Amount of replicas to be created."
+  description = "Number of replicas to be created."
   type        = number
   default     = 1
 }

--- a/variables.tf
+++ b/variables.tf
@@ -65,9 +65,9 @@ variable "aws_tags" {
 }
 
 variable "aws_load_balancer_controller_chart_version" {
-  description = "The AWS Load Balancer Controller version to use. See https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases for available versions"
+  description = "The AWS Load Balancer Controller version to use. See https://github.com/aws/eks-charts/releases/ and https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases for available versions"
   type        = string
-  default     = "1.1.1"
+  default     = "1.2.2"
 }
 
 variable "alb_controller_depends_on" {
@@ -75,7 +75,13 @@ variable "alb_controller_depends_on" {
 }
 
 variable "target_groups" {
-  description = "ARNs for existing load balancers that should be added via TargetGroupBindings. See https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/targetgroupbinding/targetgroupbinding/ for details"
+  description = "Group Binding details for TargetGroupBindings. Expected object fields: name, backend_port, target_group_arn, target_type See https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/targetgroupbinding/targetgroupbinding/ for details."
   type        = any
   default     = []
+}
+
+variable "enable_host_networking" {
+  description = "If true enable host networking. See https://github.com/aws/eks-charts/tree/master/stable/aws-load-balancer-controller#configuration for details."
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
I've updated your handy module to work with the now-so-called "AWS Load Balancer Controller" (aka v2). 

I tried to keep your conventions wherever I could. The change from docker image version to helm chart version is a breaking change, hence the major version bump. 

I hope you'll accept my PR!